### PR TITLE
Priority Fixes for review

### DIFF
--- a/Update/staffroom.txt
+++ b/Update/staffroom.txt
@@ -409,7 +409,7 @@ void main()
 	ClearMessage();
 	DisableWindow();
 
-	ModDrawCharacterWithFiltering(2, 11, "sprite/oisi2_6_", "0", "effect/left", 0, -160, 0, FALSE, 0, 0, 0, 0, 0, 1, 300, TRUE ); //ERROR_EXISTING: Priority 1 on layer 2 used here. Conflict is 13 lines away (line 425)
+	ModDrawCharacterWithFiltering(2, 11, "sprite/oisi2_6_", "0", "effect/left", 0, -160, 0, FALSE, 0, 0, 0, 0, 0, 10, 300, TRUE );
 
 
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#f5e6d3>八咫桜</color>", NULL, "<color=#f5e6d3>Yatazakura</color>", NULL, Line_ContinueAfterTyping); }
@@ -422,7 +422,7 @@ void main()
 	DisableWindow();
 
 	FadeOutBGM( 0, 300, TRUE );
-	ModDrawCharacter(1, 14, "sprite/oko3_def_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 2, 300, TRUE ); //ERROR: Priority 1 already in use 13 lines ago (line 412). Existing Layer: 2 Conflicting Layer: 1 Suggested Priority: 2
+	ModDrawCharacter(1, 14, "sprite/oko3_def_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 0, 300, TRUE );
 	PlayBGM( 0, "4", 120, 0 );
 
 

--- a/Update/staffroom.txt
+++ b/Update/staffroom.txt
@@ -409,7 +409,7 @@ void main()
 	ClearMessage();
 	DisableWindow();
 
-	ModDrawCharacterWithFiltering(2, 11, "sprite/oisi2_6_", "0", "effect/left", 0, -160, 0, FALSE, 0, 0, 0, 0, 0, 1, 300, TRUE );
+	ModDrawCharacterWithFiltering(2, 11, "sprite/oisi2_6_", "0", "effect/left", 0, -160, 0, FALSE, 0, 0, 0, 0, 0, 1, 300, TRUE ); //ERROR_EXISTING: Priority 1 on layer 2 used here. Conflict is 13 lines away (line 425)
 
 
 	if (GetGlobalFlag(GADVMode)) { OutputLine("<color=#f5e6d3>八咫桜</color>", NULL, "<color=#f5e6d3>Yatazakura</color>", NULL, Line_ContinueAfterTyping); }
@@ -422,7 +422,7 @@ void main()
 	DisableWindow();
 
 	FadeOutBGM( 0, 300, TRUE );
-	ModDrawCharacter(1, 14, "sprite/oko3_def_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 0, 300, TRUE );
+	ModDrawCharacter(1, 14, "sprite/oko3_def_", "0", 160, 0, 0, FALSE, 0, 0, 0, 0, 0, 0, 0, 2, 300, TRUE ); //ERROR: Priority 1 already in use 13 lines ago (line 412). Existing Layer: 2 Conflicting Layer: 1 Suggested Priority: 2
 	PlayBGM( 0, "4", 120, 0 );
 
 


### PR DESCRIPTION
# NOTE
 
In this case, the second draw call uses priority 0. From my understanding, for certain bustshot calls, the engine will convert priority 0 to priority = layer number. The layer number is 1 for the second call, so it will use priroity 1, which is already used earlier.
 
 
 ----
 
 - Includes automatically fixed priority on lines with error
 - Please delete //ERROR_EXISTING: comments, those are just to indicate where priority was last used